### PR TITLE
normalize passing situation

### DIFF
--- a/src/cljc/game_of_ur/game/board.cljc
+++ b/src/cljc/game_of_ur/game/board.cljc
@@ -121,7 +121,7 @@
   [{:keys [roll player origin] :as move}]
   (spec/assert ::move move)
   (let [path (get paths player)
-        destination (if (= :pass origin)
+        destination (if (or (zero? roll) (= :pass origin))
                       :pass
                       (get path (+ roll (.indexOf path origin))))]
     (assoc move :destination destination)))
@@ -135,11 +135,12 @@
      - Either the destination is empty, or there is an oppnent stone on it and
        the square is not a member of rosettes."
   [{:keys [home turn stones] :as board}
-   {:keys [player origin destination] :as move}]
+   {:keys [player origin destination roll] :as move}]
   (spec/assert ::board board)
   (spec/assert ::move move)
   (let [in-destination (get stones destination)]
     (and destination
+         (not= 0 roll)
          (= turn player)
          (or (not= origin :home) (> (home player) 0))
          (or (= origin :home) (= player (get stones origin)))

--- a/test/clj/game_of_ur/test/game/board.clj
+++ b/test/clj/game_of_ur/test/game/board.clj
@@ -17,10 +17,9 @@
 (def invalid-move-black-goal {:roll 1, :origin :goal, :player :black})
 
 (def pass-move {:roll 3, :origin :pass, :player :black})
+(def pass-move-0 {:roll 0, :origin :pass, :player :black})
 
 (deftest move-destination
-  (is (= :home (:destination (b/full-move move-white-home-0))))
-  (is (= :home (:destination (b/full-move move-black-home-0))))
   (is (= [-3 0] (:destination (b/full-move move-white-1))))
   (is (= [-2 0] (:destination (b/full-move move-white-2))))
   (is (= [-1 0] (:destination (b/full-move move-black-1))))
@@ -53,15 +52,15 @@
 
 
 (deftest valid-move?
-  (is (b/valid-move? b/initial-board (b/full-move move-white-home-0)))
+  (is (not (b/valid-move? b/initial-board (b/full-move move-white-home-0))))
   (is (b/valid-move? b/initial-board (b/full-move move-white-home-3)))
   (is (not (b/valid-move? b/initial-board (b/full-move move-black-home-0)))) ; white turn
   (is (not (b/valid-move? b/initial-board (b/full-move move-white-0)))) ; can't move when rolling 0
   (is (not (b/valid-move? b/initial-board (b/full-move move-white-1)))) ; no stone at [-3 -1] origin
-  (is (b/valid-move? white-turn (b/full-move move-white-home-0)))
+  (is (not (b/valid-move? white-turn (b/full-move move-white-home-0))))
   (is (not (b/valid-move? white-turn (b/full-move move-white-1)))) ; stone at [-3 -1] is black
   (is (b/valid-move? white-turn (b/full-move move-white-2)))
-  (is (b/valid-move? black-turn-1 (b/full-move move-black-home-0)))
+  (is (not (b/valid-move? black-turn-1 (b/full-move move-black-home-0))))
   (is (not (b/valid-move? black-turn-1 (b/full-move move-white-1)))) ; black turn
   (is (not (b/valid-move? black-turn-1 (b/full-move move-black-1)))) ; no stone at [2 0] origin
   (is (not (b/valid-move? black-turn-2 (b/full-move move-black-home-0)))) ; no stone at home
@@ -78,11 +77,11 @@
 
 (deftest child-board
   (is (= (clear-nil-stones (assoc b/initial-board :turn :black))
-         (clear-nil-stones (b/child-board b/initial-board (b/full-move move-white-home-0)))))
+         (clear-nil-stones (b/child-board b/initial-board (b/full-move pass-move-0)))))
   (is (= {:home {:black 7, :white 6}, :turn :black, :stones {[-2 -1] :white}}
          (clear-nil-stones (b/child-board b/initial-board (b/full-move move-white-home-3)))))
   (is (= (clear-nil-stones (assoc white-turn :turn :black))
-         (clear-nil-stones (b/child-board white-turn (b/full-move move-white-home-0)))))
+         (clear-nil-stones (b/child-board white-turn (b/full-move pass-move-0)))))
   (is (= {:home {:white 3, :black 6}, :turn :black, :stones {[-3 -1] :black, [-2 0] :white}} ; black captured
          (clear-nil-stones (b/child-board white-turn (b/full-move move-white-2)))))
   (is (= (clear-nil-stones (assoc black-turn-1 :turn :white))


### PR DESCRIPTION
we currently have two ways of having a move that just changes the `turn` to the opponent
```
{:origin :home :roll 0 :player _ :destination :home}
```
```
{:origin :pass :roll _ :player _ :destination :pass}
```
That gave me problems when working with this. So I think we should narrow that options to the second